### PR TITLE
MatchFilter 作成

### DIFF
--- a/filters.rb
+++ b/filters.rb
@@ -95,6 +95,22 @@ class TrimFilter
   end
 end
 
+# MatchFilter
+class MatchFilter
+  include FilterFunctionInterface
+
+  def initialize(pattern)
+    @pattern = pattern
+  end
+
+  def filter(doc)
+    doc = TextFilter.new.filter(doc) if nokogiri?(doc)
+    reuslt = doc.match(@pattern)
+    return reuslt[0] if count(reuslt) > 0
+    ''
+  end
+end
+
 def get_filter(token)
   filter =
     case token
@@ -103,6 +119,7 @@ def get_filter(token)
     when 'html{}' then HtmlFilter.new
     when 'trim{}' then TrimFilter.new
     when /attr{(.*)}/ then AttrFilter.new(Regexp.last_match[1])
+    when /match{(.*)}/ then MatchFilter.new(Regexp.last_match[1])
     else raise UndefinedFilter
     end
   filter

--- a/filters.rb
+++ b/filters.rb
@@ -105,8 +105,8 @@ class MatchFilter
 
   def filter(doc)
     doc = TextFilter.new.filter(doc) if nokogiri?(doc)
-    reuslt = doc.match(@pattern)
-    return reuslt[0] if count(reuslt) > 0
+    reuslt = doc.match(Regexp.new(@pattern))
+    return reuslt[0] unless reuslt.nil?
     ''
   end
 end


### PR DESCRIPTION
## MatchFilter 作成

`match{(正規表現)}` でマッチング後の文字列に置き換えるフィルタを作成

以下サンプル
```
{
  "title:`#eow-title text{}`": "string",
  "watch-count:`#watch7-views-info > div.watch-view-count text{} match{([\\d,]+)}`": "string"
}
```