### PR TITLE
Gem ファイル化

### DIFF
--- a/higokami.gemspec
+++ b/higokami.gemspec
@@ -2,7 +2,6 @@
 
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'higokami/version'
 
 Gem::Specification.new do |spec|
   spec.name          = 'higokami'

--- a/lib/higokami.rb
+++ b/lib/higokami.rb
@@ -3,7 +3,6 @@ require 'open-uri'
 require 'open_uri_redirections'
 require 'nokogiri'
 
-require 'higokami/version'
 require 'higokami/serializer.rb'
 
 # Higokami

--- a/lib/higokami/nodeparser.rb
+++ b/lib/higokami/nodeparser.rb
@@ -1,4 +1,4 @@
-require 'filters.rb'
+require 'higokami/filters.rb'
 
 # convert return node value by key type
 def return_node(node, tkey, filters)

--- a/lib/higokami/nodeparser.rb
+++ b/lib/higokami/nodeparser.rb
@@ -1,4 +1,4 @@
-require 'web2json/filters.rb'
+require 'filters.rb'
 
 # convert return node value by key type
 def return_node(node, tkey, filters)

--- a/lib/higokami/serializer.rb
+++ b/lib/higokami/serializer.rb
@@ -3,7 +3,7 @@ require 'open_uri_redirections'
 require 'nokogiri'
 require 'json'
 
-require 'nodeparser.rb'
+require 'higokami/nodeparser.rb'
 
 Key = Struct.new(:key_org, :key, :is_array, :selector)
 

--- a/lib/higokami/serializer.rb
+++ b/lib/higokami/serializer.rb
@@ -3,7 +3,7 @@ require 'open_uri_redirections'
 require 'nokogiri'
 require 'json'
 
-require 'higokami/nodeparser.rb'
+require 'nodeparser.rb'
 
 Key = Struct.new(:key_org, :key, :is_array, :selector)
 


### PR DESCRIPTION
このライブラリを Gem ファイル化する変更を行った。

## コンパイル方法

```
$ rake build
$ rake install
# -> pkg/higokami-0.1.0.gem が生成される
```

## インストール方法

```
$ gem install pkg/higokami-0.1.0.gem
```

## 使用方法

- Hacker News をスクレイプする例

```ruby
require 'higokami'

higokami = Higokami.new('news.ycombinator.com/index.json')
puts higokami.parse('https://news.ycombinator.com/')
```